### PR TITLE
update open glossary logo with State of the Edge

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -26,7 +26,7 @@ landscape:
             homepage_url: 'https://www.lfedge.org/projects-old/openglossary'
             project: growth
             repo_url: 'https://github.com/State-of-the-Edge/glossary'
-            logo: box_glossary.svg
+            logo: 'https://raw.githubusercontent.com/lf-edge/artwork/master/stateoftheedge/horizontal/color/stateoftheedge-horizontal-color.svg'
             twitter: 'https://twitter.com/LF_Edge'
             crunchbase: 'https://www.crunchbase.com/organization/lf-edge'
           - item:


### PR DESCRIPTION
Updating the Open Glossary logo to State of the Edge within .org category