### PR TITLE
update OpenStack to Open Infrastructure Foundation

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -42,10 +42,9 @@ landscape:
             twitter: 'https://twitter.com/open19in'
             crunchbase: 'https://www.crunchbase.com/organization/open19-foundation'
           - item:
-            name: OpenStack
-            homepage_url: 'https://www.openstack.org/'
-            logo: >-
-              https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/2016R/OpenStack-Logo-Vertical.svg
+            name: Open Infrastructure Foundation
+            homepage_url: 'https://openinfra.dev/'
+            logo: 'https://openinfra.dev/static/OIF-logo-1a1b6164b85d649cc12a9352ef566d90.svg'
             crunchbase: 'https://www.crunchbase.com/organization/openstack'
           - item:
             name: Wireless Infrastructure Association


### PR DESCRIPTION
Align with OpenStack's rebranding to Open Infrastructure Foundation. (Crunchbase link left as is, no new entry created yet.)